### PR TITLE
#106468 Работа с единственным экземпляром менеджера через фасад

### DIFF
--- a/tests/HighLevelProducerTest.php
+++ b/tests/HighLevelProducerTest.php
@@ -1,6 +1,9 @@
 <?php
 
+use Ensi\LaravelPhpRdKafka\KafkaFacade;
+use Ensi\LaravelPhpRdKafkaProducer\HighLevelProducer;
 use Ensi\LaravelPhpRdKafkaProducer\Tests\HighLevelProducerFactory;
+use RdKafka\Producer;
 
 test('producer is instantiable', function () {
     expect(HighLevelProducerFactory::new()->make())->toBeObject();
@@ -11,17 +14,28 @@ test('producer can push middleware', function () {
     $producer->pushMiddleware('TestMiddleware::class');
     $producer->pushMiddleware('TestMiddleware2::class');
     $producer->pushMiddleware('TestMiddleware::class');
-    expect($producer->collectMiddleware())->toBeArray(['TestMiddleware::class', 'TestMiddleware2::class']);
+    expect($producer->collectMiddleware())->toBe(['TestMiddleware::class', 'TestMiddleware2::class']);
 });
 
-test('producer uses global middleware in the begining', function () {
+test('producer uses global middleware in the beginning', function () {
     config()->set('kafka-producer.global_middleware', ['GlobalMiddleware::class']);
 
     $producer = HighLevelProducerFactory::new()->make();
     $producer->pushMiddleware('TestMiddleware::class');
-    expect($producer->collectMiddleware())->toBeArray(['GlobalMiddleware::class', 'TestMiddleware::class']);
+    expect($producer->collectMiddleware())->toBe(['GlobalMiddleware::class', 'TestMiddleware::class']);
 });
 
 test('undefined topic throws exception', function () {
     HighLevelProducerFactory::new()->make('not-registered-topic-key');
 })->throws(InvalidArgumentException::class);
+
+test('producer is singleton', function () {
+    $stub = new class('default') extends HighLevelProducer {
+        public function getProducer(): Producer
+        {
+            return $this->producer;
+        }
+    };
+
+    expect($stub->getProducer())->toBe(KafkaFacade::producer('default'));
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,9 +2,17 @@
 
 namespace Ensi\LaravelPhpRdKafkaProducer\Tests;
 
+use Ensi\LaravelPhpRdKafka\LaravelPhpRdKafkaServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
 
 class TestCase extends Orchestra
 {
     protected $loadEnvironmentVariables = true;
+
+    protected function getPackageProviders($app): array
+    {
+        return [
+            LaravelPhpRdKafkaServiceProvider::class,
+        ];
+    }
 }


### PR DESCRIPTION
Одиночный экземпляр KafkaManager регистрируется под именем "kafka", а не под именем класса. В результате для каждого экземпляра HighLevelProducer создается отдельный экземпляр менеджера и отдельное подключение к топику.

В PR сделал обращения к менеджеру через фасад.